### PR TITLE
Hotfix firefox calendar wrapping

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -191,7 +191,7 @@ exports['default'] = function () {
     cellMargin = customTheme.Day.margin;
   }
 
-  var cellSize = (parseInt(calendarWidth) - parseInt(calendarPadding) * 2) / 7 - parseInt(cellMargin) * 2;
+  var cellSize = Math.floor((( parseInt(calendarWidth) - parseInt(calendarPadding) * 2 ) / 7 ) - ( parseInt(cellMargin) * 2 ));
 
   return {
     DateRange: _extends({}, defaultTheme.DateRange, customTheme.DateRange),

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gfpacheco/react-date-range",
+  "name": "@moblee/react-date-range",
   "version": "0.9.5",
   "description": "A React component for choosing dates and date ranges.",
   "main": "lib/index.js",


### PR DESCRIPTION
## Fixes PR
 - https://github.com/Adphorus/react-date-range/pull/170/commits/3be484fef4487f54ac8848138e8f0ff5e40771a1

 - Updates package name so it could be added in `package.json` as `@moblee/react-date-range`